### PR TITLE
Feature: Custom breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add `useDevice` breakpoint params
+
 ## [0.2.4] - 2019-12-10
 
 ## [0.2.3] - 2019-10-28

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Use this app's HOC or hook to find out current device's viewport size.
 #### useDevice
 
 Returns an object with the format of `DeviceInfo` defined as:
+
 ```js
 interface DeviceInfo {
   device: Device
@@ -24,7 +25,7 @@ enum Device {
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
   const { isMobile } = useDevice()
-  if (isMobile) { 
+  if (isMobile) {
     // is phone or tablet!
   }
   return ...
@@ -37,10 +38,32 @@ or
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
   const { device } = useDevice()
-  if (device === 'tablet') { 
+  if (device === 'tablet') {
     //is tablet!
   }
   return ...
+}
+```
+
+or even with custom breakpoints
+
+```js
+import { useDevice } from 'vtex.device-detector'
+const MyComponent = props => {
+  const { device } = useDevice({ large: '61.25rem' }) // custom breakpoint argument
+  if (device === 'tablet') {
+    //is tablet!
+  }
+  return ...
+}
+```
+
+you can specify custom breakpoints using the following specification:
+
+```typescript
+interface Breakpoints {
+  medium: string;
+  large: string;
 }
 ```
 
@@ -63,7 +86,7 @@ enum Device {
 ```js
 import { withDevice } from 'vtex.device-detector'
 const MyComponent = props => {
-  if (props.isMobile) { 
+  if (props.isMobile) {
     // is phone or tablet!
   }
   return ...
@@ -77,7 +100,7 @@ or
 ```js
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
-  if (props.device === 'tablet') { 
+  if (props.device === 'tablet') {
     //is tablet!
   }
   return ...

--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ const MyComponent = props => {
 }
 ```
 
-or even with custom breakpoints
+**⚠ Experimental**
+With custom breakpoints
 
 ```js
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
-  const { device } = useDevice({ large: '61.25rem' }) // custom breakpoint argument
+  const experimentalBreakpoints = { large: '61.25rem' };
+  const { device } = useDevice({ experimentalBreakpoints }) // custom breakpoint argument
   if (device === 'tablet') {
     //is tablet!
   }
@@ -61,9 +63,13 @@ const MyComponent = props => {
 you can specify custom breakpoints using the following specification:
 
 ```typescript
+interface useDeviceOptions {
+  experimentalBreakpoints?: Breakpoints;
+}
+
 interface Breakpoints {
-  medium: string;
-  large: string;
+  medium?: string;
+  large?: string;
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use this app's HOC or hook to find out current device's viewport size.
 #### useDevice
 
 Returns an object with the format of `DeviceInfo` defined as:
+
 ```js
 interface DeviceInfo {
   device: Device
@@ -24,7 +25,7 @@ enum Device {
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
   const { isMobile } = useDevice()
-  if (isMobile) { 
+  if (isMobile) {
     // is phone or tablet!
   }
   return ...
@@ -37,10 +38,32 @@ or
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
   const { device } = useDevice()
-  if (device === 'tablet') { 
+  if (device === 'tablet') {
     //is tablet!
   }
   return ...
+}
+```
+
+or even with custom breakpoints
+
+```js
+import { useDevice } from 'vtex.device-detector'
+const MyComponent = props => {
+  const { device } = useDevice({ large: '61.25rem' }) // custom breakpoint argument
+  if (device === 'tablet') {
+    //is tablet!
+  }
+  return ...
+}
+```
+
+you can specify custom breakpoints using the following specification:
+
+```typescript
+interface Breakpoints {
+  medium: string;
+  large: string;
 }
 ```
 
@@ -63,7 +86,7 @@ enum Device {
 ```js
 import { withDevice } from 'vtex.device-detector'
 const MyComponent = props => {
-  if (props.isMobile) { 
+  if (props.isMobile) {
     // is phone or tablet!
   }
   return ...
@@ -77,7 +100,7 @@ or
 ```js
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
-  if (props.device === 'tablet') { 
+  if (props.device === 'tablet') {
     //is tablet!
   }
   return ...

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,12 +45,14 @@ const MyComponent = props => {
 }
 ```
 
-or even with custom breakpoints
+**⚠ Experimental**
+With custom breakpoints
 
 ```js
 import { useDevice } from 'vtex.device-detector'
 const MyComponent = props => {
-  const { device } = useDevice({ large: '61.25rem' }) // custom breakpoint argument
+  const experimentalBreakpoints = { large: '61.25rem' };
+  const { device } = useDevice({ experimentalBreakpoints }) // custom breakpoint argument
   if (device === 'tablet') {
     //is tablet!
   }
@@ -61,9 +63,13 @@ const MyComponent = props => {
 you can specify custom breakpoints using the following specification:
 
 ```typescript
+interface useDeviceOptions {
+  experimentalBreakpoints?: Breakpoints;
+}
+
 interface Breakpoints {
-  medium: string;
-  large: string;
+  medium?: string;
+  large?: string;
 }
 ```
 

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,7 @@
     "eslint": "^5.16.0",
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "0.2.4"
 }

--- a/react/useDevice.tsx
+++ b/react/useDevice.tsx
@@ -12,15 +12,24 @@ export enum Device {
   desktop = 'desktop',
 }
 
-const useDevice = () => {
+interface Breakpoints {
+  medium: string
+  large: string
+}
+
+const useDevice = (breakpoints?: Breakpoints) => {
+  const { medium, large } = breakpoints || {
+    medium: '40rem',
+    large: '61.25rem',
+  }
   const isSSR = useSSR()
   const { hints } = useRuntime()
 
   /** These screensizes are hardcoded, based on the default
    * Tachyons breakpoints. They should probably be the ones
    * configured via the style.json file, if available. */
-  const isScreenMedium = useMedia({ minWidth: '40rem' })
-  const isScreenLarge = useMedia({ minWidth: '64.1rem' })
+  const isScreenMedium = useMedia({ minWidth: medium })
+  const isScreenLarge = useMedia({ minWidth: large })
 
   if (isSSR) {
     return {

--- a/react/useDevice.tsx
+++ b/react/useDevice.tsx
@@ -13,19 +13,22 @@ export enum Device {
 }
 
 interface Breakpoints {
-  medium: string
-  large: string
+  medium?: string
+  large?: string
 }
 
-const useDevice = (breakpoints?: Breakpoints) => {
+interface UseDeviceOptions {
+  experimentalBreakpoints?: Breakpoints
+}
+
+const useDevice = (options?: UseDeviceOptions) => {
+  const { experimentalBreakpoints = {} } = options || {}
+
   /** These screensizes are hardcoded, based on the default
    * Tachyons breakpoints. They should probably be the ones
    * configured via the style.json file, if available. */
+  const { medium = '40rem', large = '64.1rem' } = experimentalBreakpoints
 
-  const { medium, large } = breakpoints || {
-    medium: '40rem',
-    large: '64.1rem',
-  }
   const isSSR = useSSR()
   const { hints } = useRuntime()
   const isScreenMedium = useMedia({ minWidth: medium })

--- a/react/useDevice.tsx
+++ b/react/useDevice.tsx
@@ -18,16 +18,16 @@ interface Breakpoints {
 }
 
 const useDevice = (breakpoints?: Breakpoints) => {
-  const { medium, large } = breakpoints || {
-    medium: '40rem',
-    large: '61.25rem',
-  }
-  const isSSR = useSSR()
-  const { hints } = useRuntime()
-
   /** These screensizes are hardcoded, based on the default
    * Tachyons breakpoints. They should probably be the ones
    * configured via the style.json file, if available. */
+
+  const { medium, large } = breakpoints || {
+    medium: '40rem',
+    large: '64.1rem',
+  }
+  const isSSR = useSSR()
+  const { hints } = useRuntime()
   const isScreenMedium = useMedia({ minWidth: medium })
   const isScreenLarge = useMedia({ minWidth: large })
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5071,10 +5071,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.4.3"


### PR DESCRIPTION
#### What problem is this solving?

Breakpoint definitions are hardcoded.
Although we expect it to inherit breakpoint definitions from styles builder in the future this would allow further customization in the meantime.  

#### How should this be manually tested?

- Go to [Workspace](https://fixsliderbreakpoint--unimarcdev.myvtex.com);
- Observe that the main carousel now breaks at `60rem` (custom breakpoint);

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

```typescript
const { isMobile } = useDevice({ large: '60rem' })
```

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

I'm going to open a PR that uses this feature for [`vtex.carousel`](https://github.com/vtex-apps/carousel) as well; I'll reference it below.
