### PR TITLE
Refactor/device from runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Uses device information from runtime, instead of calculating internally.
 
 ## [0.2.4] - 2019-12-10
 

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,7 @@
     "eslint": "^5.16.0",
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
-    "typescript": "3.5.2"
+    "typescript": "3.8.3"
   },
   "version": "0.2.4"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -4,10 +4,8 @@
     "lint": "tsc --noEmit && eslint --ext ts,tsx ."
   },
   "dependencies": {
-    "@vtex/css-handles": "^1.0.0",
     "react": "^16.8.3",
-    "react-dom": "^16.8.3",
-    "use-media": "^1.3.0"
+    "react-dom": "^16.8.3"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/react/useDevice.tsx
+++ b/react/useDevice.tsx
@@ -12,9 +12,23 @@ export enum Device {
 }
 
 const useDevice = () => {
-  const {
-    deviceInfo: { type: device, isMobile },
-  } = useRuntime()
+  const { deviceInfo, hints } = useRuntime()
+
+  if (!deviceInfo) {
+    /** Fallback code to support transition to device info coming
+     * from render-runtime. Should be removed in the near future */
+
+    return {
+      device: hints.phone
+        ? Device.phone
+        : hints.tablet
+        ? Device.tablet
+        : Device.desktop,
+      isMobile: hints.mobile,
+    }
+  }
+
+  const { type: device, isMobile } = deviceInfo
 
   return { device, isMobile }
 }

--- a/react/useDevice.tsx
+++ b/react/useDevice.tsx
@@ -1,5 +1,4 @@
-import { useMedia } from 'use-media'
-import { useSSR, useRuntime } from 'vtex.render-runtime'
+import { useRuntime } from 'vtex.render-runtime'
 
 export interface DeviceInfo {
   device: Device
@@ -13,34 +12,11 @@ export enum Device {
 }
 
 const useDevice = () => {
-  const isSSR = useSSR()
-  const { hints } = useRuntime()
+  const {
+    deviceInfo: { type: device, isMobile },
+  } = useRuntime()
 
-  /** These screensizes are hardcoded, based on the default
-   * Tachyons breakpoints. They should probably be the ones
-   * configured via the style.json file, if available. */
-  const isScreenMedium = useMedia({ minWidth: '40rem' })
-  const isScreenLarge = useMedia({ minWidth: '64.1rem' })
-
-  if (isSSR) {
-    return {
-      device: hints.phone
-        ? Device.phone
-        : hints.tablet
-        ? Device.tablet
-        : Device.desktop,
-      isMobile: hints.mobile,
-    }
-  }
-
-  return {
-    device: isScreenLarge
-      ? Device.desktop
-      : isScreenMedium
-      ? Device.tablet
-      : Device.phone,
-    isMobile: !isScreenLarge,
-  }
+  return { device, isMobile }
 }
 
 export default useDevice

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1023,11 +1023,6 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/css-handles@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@vtex/css-handles/-/css-handles-1.1.0.tgz#c49998230e7b1576bef4ea6125471137a54c6c86"
-  integrity sha512-GP5ONxBimQoKRIW8WjUCI5/HU13JdMTxPw1aoumWcDv3ycUu13IR8HzzIuTM+iFZE9ctvGZfVCq9FXqQ747yNw==
-
 "@vtex/test-tools@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-0.2.0.tgz#3bb202a918bd60201ae23c55901d7308e638743c"
@@ -5146,11 +5141,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-use-media@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.3.0.tgz#be26102fd954c78895b4934744f977d2b23ecfbb"
-  integrity sha512-1JuB/QVAxCXsIsexSMTMZ34egbroSEjmvOVFbvGqLACruJcaH4wZjnUqqwQh/iVtbWi73LDCbfYJDsdyDfJe+g==
 
 use@^3.1.0:
   version "3.1.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5071,10 +5071,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.4.3"


### PR DESCRIPTION
Uses device information from runtime context, instead of calculating it internally. This allows the runtime context controlling display of blocks on the entire page, depending, for example, on which blocks are loaded.

The motivation and test cases can be found here https://github.com/vtex-apps/render-runtime/pull/521
